### PR TITLE
Version 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.3.1] - 2023-03-06
+
+- Fixed a bug where keys with empty values were being populated when using
+`at()` against a non-existant key and the values passed to `combine!`, `set!`,
+  or `default` resolved to no values or where `remove!` removed all values.
+
 ## [1.3.0] - 2023-03-03
 
 - Added `at().remove!` option for removing values.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bundle install
 
 ## General Usage
 
-Initialize a `TagOptions::Hash` directly or by passing an existing `Hash`.
+Instantiate a `TagOptions::Hash` directly or by passing an existing `Hash`.
 
 ```ruby
 TagOptions::Hash.new
@@ -74,6 +74,24 @@ TagOptions::Hash.new
 hash = {class: "flex"}
 TagOptions::Hash.new(hash)
 => {:class=>"flex"}
+```
+
+Similar to `Array()`, you can also instantiate a new `TagOptions::Hash` by
+passing a has to `TagOptions::Hash()`.
+
+```ruby
+hash = {class: "flex"}
+TagOptions::Hash(hash)
+=> {:class=>"flex"}
+```
+
+The values of the hash passed to `TagOptions::Hash.new` or `TagOptions::Hash()`
+are automatically converted to strings.
+
+```ruby
+hash = {disabled: true}
+TagOptions::Hash.new(hash)
+=> {:disabled=>"true"}
 ```
 
 `TagOptions::Hash` inherits from `ActiveSupport::HashWithIndifferentAccess`,

--- a/lib/tag_options/hash.rb
+++ b/lib/tag_options/hash.rb
@@ -1,5 +1,6 @@
 require "active_support/callbacks"
 require "active_support/core_ext/hash/indifferent_access"
+require "active_support/core_ext/object/blank"
 require "tag_options/convert_key"
 require "tag_options/hash_at"
 require "tag_options/errors/not_hash_error"
@@ -14,8 +15,9 @@ module TagOptions
     def initialize(hash = {})
       run_callbacks :initialize do
         hash.each do |key, value|
-          self[convert_key(key)] = value.is_a?(::Hash) ? self.class.new(value) : value
+          self[convert_key(key)] = value.is_a?(::Hash) ? self.class.new(value) : value.to_s
         end
+        remove_blank!
       end
     end
 
@@ -24,21 +26,50 @@ module TagOptions
     end
 
     def dig(*keys)
-      keys = keys.map { |key| convert_key(key) }
-      keys.size.zero? ? self : super(*keys)
+      return self if keys.size.zero?
+
+      dug_keys = []
+      data = self
+      keys.each_with_index do |key, index|
+        key = convert_key(key)
+        return nil unless data.key?(key)
+
+        data = data[key]
+        dug_keys << key
+        last_key = index == keys.size - 1
+        unless last_key || data.is_a?(self.class)
+          raise TagOptions::Errors::NotHashError.new(dug_keys, type: data.class)
+        end
+      end
+      data
     end
 
     def populate!(*keys)
       populated_keys = []
       data = self
       keys.each do |key|
-        data[convert_key(key)] ||= self.class.new
-        data = data[convert_key(key)]
+        key = convert_key(key)
+        data[key] ||= self.class.new
+        data = data[key]
+        populated_keys << key
         unless data.is_a?(self.class)
           raise TagOptions::Errors::NotHashError.new(populated_keys, type: data.class)
         end
       end
       self
+    end
+
+    def remove_blank!(hash = self, parent_hash: nil)
+      hash.each do |key, value|
+        if value.blank?
+          hash.delete(key)
+          remove_blank!(parent_hash) if parent_hash
+        elsif value.is_a?(Hash)
+          remove_blank!(value, parent_hash: hash)
+          remove_blank!(parent_hash) if parent_hash
+        end
+      end
+      hash
     end
   end
 end

--- a/lib/tag_options/hash.rb
+++ b/lib/tag_options/hash.rb
@@ -63,10 +63,10 @@ module TagOptions
       hash.each do |key, value|
         if value.blank?
           hash.delete(key)
-          remove_blank!(parent_hash) if parent_hash
+          remove_blank!(parent_hash, parent_hash: nil) if parent_hash
         elsif value.is_a?(Hash)
           remove_blank!(value, parent_hash: hash)
-          remove_blank!(parent_hash) if parent_hash
+          remove_blank!(parent_hash, parent_hash: nil) if parent_hash
         end
       end
       hash

--- a/lib/tag_options/hash_at.rb
+++ b/lib/tag_options/hash_at.rb
@@ -13,23 +13,19 @@ module TagOptions
     end
 
     def combine!(*values, **conditions)
-      @opt_hash.populate!(*@keys)
       current_value = @opt_hash.dig(*@keys, @value_key)
       set_value! @resolver.call(current_value, *values, **conditions)
     end
 
     def default!(*values, **conditions)
-      @opt_hash.populate!(*@keys)
       set_default! @resolver.call(*values, **conditions)
     end
 
     def set!(*values, **conditions)
-      @opt_hash.populate!(*@keys)
       set_value! @resolver.call(*values, **conditions)
     end
 
     def remove!(*values, **conditions)
-      @opt_hash.populate!(*@keys)
       regex_values, values = values.flatten.partition { |v| v.is_a?(Regexp) }
       remove_values!(*regex_values, *@resolver.values(*values, **conditions))
     end
@@ -37,7 +33,7 @@ module TagOptions
     private
 
     def remove_values!(*values_to_remove)
-      values = @resolver.values(@opt_hash.dig(*@keys)[@value_key])
+      values = @resolver.values(@opt_hash.dig(*@keys)&.[](@value_key))
       values_to_remove.each do |value|
         if value.is_a?(Regexp)
           values.reject! { |current_value| value.match?(current_value) }
@@ -45,17 +41,25 @@ module TagOptions
           values.reject! { |current_value| value == current_value }
         end
       end
+      @opt_hash.populate!(*@keys)
       @opt_hash.dig(*@keys)[@value_key] = @resolver.call(*values)
+      @opt_hash.remove_blank!
       @opt_hash
     end
 
     def set_default!(value)
+      return @opt_hash if value.blank?
+
+      @opt_hash.populate!(*@keys)
       root = @opt_hash.dig(*@keys)
       root[@value_key] = value unless root.key?(@value_key)
       @opt_hash
     end
 
     def set_value!(value)
+      return @opt_hash if value.blank?
+
+      @opt_hash.populate!(*@keys)
       @opt_hash.dig(*@keys)[@value_key] = value
       @opt_hash
     end

--- a/lib/tag_options/version.rb
+++ b/lib/tag_options/version.rb
@@ -1,3 +1,3 @@
 module TagOptions
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end

--- a/spec/lib/tag_options/at_combine_spec.rb
+++ b/spec/lib/tag_options/at_combine_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe TagOptions::Hash do
       expect(options[:class]).not_to include(values.to_s)
       expect(options[:class]).to include(*values)
     end
+
+    it "is expected do nothing when no values are resolved on a non-existant root key" do
+      options.at(:nonexistant).combine!(conditional_value: false)
+      expect(options).not_to have_key(:nonexistant)
+    end
+
+    it "is expected do nothing when no values are resolved on a non-existant nested hash" do
+      options.at(:nonexistant, :nested).combine!(conditional_value: false)
+      expect(options).not_to have_key(:nonexistant)
+    end
   end
 
   context "#at(as: :style).combine!" do
@@ -69,6 +79,16 @@ RSpec.describe TagOptions::Hash do
     it "is expected to skip malformed styles" do
       options.at(:style, as: :style).combine!("display:")
       expect(options[:style]).to eq("display: none;")
+    end
+
+    it "is expected do nothing when no values are resolved on a non-existant root key" do
+      options.at(:nonexistant, as: :style).combine!("display: none;": false)
+      expect(options).not_to have_key(:nonexistant)
+    end
+
+    it "is expected do nothing when no values are resolved on a non-existant nested hash" do
+      options.at(:nonexistant, :nested, as: :style).combine!("display: none;": false)
+      expect(options).not_to have_key(:nonexistant)
     end
   end
 end

--- a/spec/lib/tag_options/at_default_spec.rb
+++ b/spec/lib/tag_options/at_default_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe TagOptions::Hash do
     {
       class: "ml-1",
       style: "display: none;",
-      data: {controller: "dropdown", "dropdown-override-value": nil},
-      disabled: false
+      data: {controller: "dropdown"}
     }
   end
 
@@ -33,16 +32,14 @@ RSpec.describe TagOptions::Hash do
       expect(options.dig(:data, :controller)).to eq("dropdown")
     end
 
-    it "is expected not to set an explicity defined false value" do
-      options.at(:disabled).default!(true)
-      expect(options).to have_key(:disabled)
-      expect(options[:disabled]).to be_falsey
+    it "is expected do nothing when no values are resolved on a non-existant root key" do
+      options.at(:nonexistant).default!(conditional_value: false)
+      expect(options).not_to have_key(:nonexistant)
     end
 
-    it "is expected not to set an explicity defined nil value" do
-      options.at(:data, "dropdown-override-value").default!("blue")
-      expect(options[:data]).to have_key("dropdown-override-value")
-      expect(options.dig(:data, "dropdown-override-value")).to be_nil
+    it "is expected do nothing when no values are resolved on a non-existant nested hash" do
+      options.at(:nonexistant, :nested).default!(conditional_value: false)
+      expect(options).not_to have_key(:nonexistant)
     end
   end
 
@@ -52,13 +49,19 @@ RSpec.describe TagOptions::Hash do
       expect(options[:style]).to eq("display: none;")
     end
 
-    context "with non-existing style" do
-      let(:hash) { {} }
+    it "is expected to set a non-existing style key" do
+      options.at(:nonexistant, as: :style).default!("color: red;")
+      expect(options[:nonexistant]).to eq("color: red;")
+    end
 
-      it "is expected to set a non-existing style key" do
-        options.at(:style, as: :style).default!("color: red;")
-        expect(options[:style]).to eq("color: red;")
-      end
+    it "is expected do nothing when no values are resolved on a non-existant root key" do
+      options.at(:nonexistant, as: :style).default!("display: none;": false)
+      expect(options).not_to have_key(:nonexistant)
+    end
+
+    it "is expected do nothing when no values are resolved on a non-existant nested hash" do
+      options.at(:nonexistant, :nested, as: :style).default!("display: none;": false)
+      expect(options).not_to have_key(:nonexistant)
     end
   end
 end

--- a/spec/lib/tag_options/at_remove_spec.rb
+++ b/spec/lib/tag_options/at_remove_spec.rb
@@ -36,6 +36,26 @@ RSpec.describe TagOptions::Hash do
       options.at(:data, :controller).remove!(/sition\z/)
       expect(options.dig(:data, :controller)).to eq("dropdown")
     end
+
+    it "is expected do nothing when no values are resolved on a non-existant root key" do
+      options.at(:nonexistant).remove!(conditional_value: false)
+      expect(options).not_to have_key(:nonexistant)
+    end
+
+    it "is expected do nothing when no values are resolved on a non-existant nested hash" do
+      options.at(:nonexistant, :nested).remove!(conditional_value: false)
+      expect(options).not_to have_key(:nonexistant)
+    end
+
+    it "is expected to remove the key when all values have been removed" do
+      options.at(:class).remove!("ml-1 mr-1")
+      expect(options).not_to have_key(:class)
+    end
+
+    it "is expected to remove nested keys when all values have been removed" do
+      options.at(:data, :controller).remove!("dropdown transition")
+      expect(options).not_to have_key(:data)
+    end
   end
 
   context "#at(as: :style).remove!" do
@@ -47,6 +67,16 @@ RSpec.describe TagOptions::Hash do
     it "is expected to remove a value matching a regular expression" do
       options.at(:style, as: :style).remove!(/color:/)
       expect(options[:style]).to eq("display: none;")
+    end
+
+    it "is expected do nothing when no values are resolved on a non-existant root key" do
+      options.at(:nonexistant, as: :style).remove!("display: none;": false)
+      expect(options).not_to have_key(:nonexistant)
+    end
+
+    it "is expected do nothing when no values are resolved on a non-existant nested hash" do
+      options.at(:nonexistant, :nested, as: :style).remove!("display: none;": false)
+      expect(options).not_to have_key(:nonexistant)
     end
   end
 end

--- a/spec/lib/tag_options/at_set_spec.rb
+++ b/spec/lib/tag_options/at_set_spec.rb
@@ -54,12 +54,32 @@ RSpec.describe TagOptions::Hash do
       expect(options[:class]).not_to include(values.to_s)
       expect(options[:class]).to include(*values)
     end
+
+    it "is expected do nothing when no values are resolved on a non-existant root key" do
+      options.at(:nonexistant).set!(conditional_value: false)
+      expect(options).not_to have_key(:nonexistant)
+    end
+
+    it "is expected do nothing when no values are resolved on a non-existant nested hash" do
+      options.at(:nonexistant, :nested).set!(conditional_value: false)
+      expect(options).not_to have_key(:nonexistant)
+    end
   end
 
   context "#at(as: :style).set!" do
     it "is expected to populate html styles" do
       options.at(:style, as: :style).set!("margin-right: 10px;")
       expect(options[:style]).to eq("margin-right: 10px;")
+    end
+
+    it "is expected do nothing when no values are resolved on a non-existant root key" do
+      options.at(:nonexistant, as: :style).set!("display: none;": false)
+      expect(options).not_to have_key(:nonexistant)
+    end
+
+    it "is expected do nothing when no values are resolved on a non-existant nested hash" do
+      options.at(:nonexistant, :nested, as: :style).set!("display: none;": false)
+      expect(options).not_to have_key(:nonexistant)
     end
   end
 end

--- a/spec/lib/tag_options/hash_spec.rb
+++ b/spec/lib/tag_options/hash_spec.rb
@@ -1,0 +1,30 @@
+require "tag_options/hash"
+
+RSpec.describe TagOptions::Hash do
+  subject(:options) { described_class.new(hash) }
+
+  let(:hash) {
+    {
+      empty_value_key: "",
+      nil_value_key: nil,
+      false_value_key: false,
+      true_value_key: true,
+      symbol_value_key: :symbol,
+      number_value_key: 1
+    }
+  }
+
+  context ".new" do
+    it "is expected to remove keys assigned values that evaluate to blank strings" do
+      expect(options).not_to have_key(:empty_value_key)
+      expect(options).not_to have_key(:nil_value_key)
+    end
+
+    it "is expected to convert values to strings" do
+      expect(options[:false_value_key]).to eq("false")
+      expect(options[:true_value_key]).to eq("true")
+      expect(options[:symbol_value_key]).to eq("symbol")
+      expect(options[:number_value_key]).to eq("1")
+    end
+  end
+end


### PR DESCRIPTION
- Fixed a bug where keys with empty values were being populated when using
`at()` against a non-existant key and the values passed to `combine!`, `set!`,
  or `default` resolved to no values or where `remove!` removed all values.
